### PR TITLE
Fixed last line of of Apollo Combobox Example

### DIFF
--- a/src/hooks/useCombobox/apollo-useCombobox/index.js
+++ b/src/hooks/useCombobox/apollo-useCombobox/index.js
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from 'react'
+import {render} from 'react-dom'
 import {
   ApolloProvider,
   ApolloClient,
@@ -103,4 +104,4 @@ const SEARCH_COLORS = gql`
   }
 `
 
-export default ApolloUseComboboxExample
+render(<ApolloUseComboboxExample />, document.getElementById('root'))


### PR DESCRIPTION
Last line was causing example to not load and throwing error: re.module.default is not a function. Changed to render(<ApolloUseComboboxExample />, document.getElementById('root'))