### PR TITLE
Fix for 'List scrolls to top on mouse leave #1417'

### DIFF
--- a/src/downshift/other-examples/dropdown-select-by-key/CustomDropdown/images/penguin.png
+++ b/src/downshift/other-examples/dropdown-select-by-key/CustomDropdown/images/penguin.png
@@ -1,1 +1,1 @@
-https://rawcdn.githack.com/kentcdodds/downshift-examples/0aa8c3bcc71d0d4582be72b5d988e54492d1e134/src/other-examples/dropdown-select-by-key/CustomDropdown/images/penguin.png
+https://rawcdn.githack.com/kentcdodds/downshift-examples/3c91c7d4b147ce45998be95e5e7e3be8f7a23079/src/downshift/other-examples/dropdown-select-by-key/CustomDropdown/images/penguin.png

--- a/src/hooks/useCombobox/react-virtual.js
+++ b/src/hooks/useCombobox/react-virtual.js
@@ -11,6 +11,7 @@ function getItems(search) {
 export default function App() {
   const [inputValue, setInputValue] = React.useState('')
   const items = getItems(inputValue)
+  console.log(items)
 
   const listRef = React.useRef()
 
@@ -35,8 +36,11 @@ export default function App() {
     inputValue,
     onInputValueChange: ({inputValue: newValue}) => setInputValue(newValue),
     scrollIntoView: () => {},
-    onHighlightedIndexChange: ({highlightedIndex}) =>
-      rowVirtualizer.scrollToIndex(highlightedIndex),
+    onHighlightedIndexChange: ({highlightedIndex, type}) => {
+      if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
+        rowVirtualizer.scrollToIndex(highlightedIndex)
+      }
+    },
   })
 
   return (

--- a/src/hooks/useCombobox/react-virtual.js
+++ b/src/hooks/useCombobox/react-virtual.js
@@ -11,7 +11,6 @@ function getItems(search) {
 export default function App() {
   const [inputValue, setInputValue] = React.useState('')
   const items = getItems(inputValue)
-  console.log(items)
 
   const listRef = React.useRef()
 

--- a/src/hooks/useSelect/react-virtual.js
+++ b/src/hooks/useSelect/react-virtual.js
@@ -25,8 +25,11 @@ export default function App() {
   } = useSelect({
     items,
     scrollIntoView: () => {},
-    onHighlightedIndexChange: ({highlightedIndex}) =>
-      rowVirtualizer.scrollToIndex(highlightedIndex),
+    onHighlightedIndexChange: ({highlightedIndex, type}) => {
+      if (type !== '__menu_mouse_leave__') {
+        rowVirtualizer.scrollToIndex(highlightedIndex)
+      }
+    },
   })
 
   return (

--- a/src/hooks/useSelect/react-virtual.js
+++ b/src/hooks/useSelect/react-virtual.js
@@ -26,7 +26,7 @@ export default function App() {
     items,
     scrollIntoView: () => {},
     onHighlightedIndexChange: ({highlightedIndex, type}) => {
-      if (type !== '__menu_mouse_leave__') {
+      if (type !== useSelect.stateChangeTypes.MenuMouseLeave) {
         rowVirtualizer.scrollToIndex(highlightedIndex)
       }
     },


### PR DESCRIPTION
- Action performed for `onHighlightedIndexChange` function on the `useSelect ` `react-virtual` example scrolls to top of the list, when we move mouse outside the list - [ISSUE](https://github.com/downshift-js/downshift/issues/1417)
- Checking for `changes.type` helps prevent this behaviour