### PR TITLE
fix: update downshift and fix multi selection ex

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "axios": "0.20.0",
     "classcat": "4.1.0",
     "debounce-fn": "4.0.0",
-    "downshift": "7.0.0-beta.0",
+    "downshift": "7.0.0",
     "emotion": "^9.1.3",
     "feather-icons-react": "0.2.0",
     "graphql": "0.13.2",

--- a/src/hooks/useCombobox/basic-multiple-selection.js
+++ b/src/hooks/useCombobox/basic-multiple-selection.js
@@ -88,6 +88,7 @@ function DropdownCombobox() {
               {...getItemProps({
                 item,
                 index,
+                'aria-selected': selectedItems.includes(item),
               })}
             >
               <input

--- a/src/hooks/useSelect/basic-multiple-selection.js
+++ b/src/hooks/useSelect/basic-multiple-selection.js
@@ -68,6 +68,7 @@ function DropdownSelect() {
               {...getItemProps({
                 item,
                 index,
+                'aria-selected': selectedItems.includes(item),
               })}
             >
               <input


### PR DESCRIPTION
Update to v7 and give proper values to `aria-selected` in items for the basic multiple selection examples.